### PR TITLE
fix(security): update ecstatic

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "browserify": "^13.0.0",
-    "ecstatic": "^1.4.0",
+    "ecstatic": "^3.1.1",
     "standard": "*",
     "tap-spec": "^4.0.2",
     "tape": "^4.5.1",


### PR DESCRIPTION
Bumping ecstatic to resolve a security issue flagged by github.

See https://nvd.nist.gov/vuln/detail/CVE-2016-10703